### PR TITLE
fix: make Motor non-copyable; refactor: tidy driver; test: header gtest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ __pycache__/
 *.tmp
 *.bak
 *~
+.pytest_cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-add_executable(robot_controller 
+add_executable(robot_controller
   src/motor/robot_controller.cpp
   src/motor/motor.cpp)
 
@@ -49,8 +49,6 @@ ament_target_dependencies(robot_controller rclcpp geometry_msgs std_msgs)
 ament_target_dependencies(jetank_motor_lib rclcpp)
 
 include_directories(include)
-
-
 
 # Install
 install(TARGETS robot_controller
@@ -75,5 +73,13 @@ target_include_directories(jetank_motor_lib PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_motor_header test/test_motor_header.cpp)
+  target_include_directories(test_motor_header PRIVATE include)
+  ament_target_dependencies(test_motor_header rclcpp)
+  target_link_libraries(test_motor_header jetank_motor_lib)
+endif()
 
 ament_package()

--- a/README.md
+++ b/README.md
@@ -75,3 +75,18 @@ Exported via `jetank_hardware.xml` for real hardware:
 |---|---|
 | `launch/test_urdf.launch.py` | Loads `jetank_description` URDF (xacro `use_sim:=true use_ros2_control:=true`) into `robot_state_publisher` + `joint_state_publisher_gui` + RViz. Does **not** start `robot_controller` or `controller_manager`. |
 | `launch/gazebo_sim.launch.py` | **Deprecated** (Gazebo Classic). Emits a deprecation notice only; use `jetank_simulation` launches instead. |
+
+## Tests
+
+C++ gtest contract tests for the `Motor` driver header. `Motor` cannot be unit-instantiated (its constructor opens an I2C device), so the tests assert its public contract at compile time via `<type_traits>`, linking against the real `motor.cpp` through `jetank_motor_lib`.
+
+| File | Imports | Asserts |
+|---|---|---|
+| `test/test_motor_header.cpp` | `motor.hpp` (the `Motor` class) | `Motor` is **not** default-constructible (only ctor needs a logger + motor number); is **not** copy-constructible or copy-assignable (owns an `i2c_fd_`, held via `unique_ptr` — prevents double-close); the `Motor(rclcpp::Logger, int, double=1.0, double=0.0)` constructor signature stays callable with required and full arg lists; the `setValue(double)` / `stop()` public control surface keeps its member-pointer signatures. |
+
+Run (built + executed by colcon):
+
+```bash
+colcon test --packages-select jetank_motor_control
+colcon test-result --verbose
+```

--- a/include/motor.hpp
+++ b/include/motor.hpp
@@ -4,30 +4,35 @@
 #include <cstdint>
 #include "rclcpp/rclcpp.hpp"
 
-class Motor {
+class Motor
+{
 public:
-    Motor(rclcpp::Logger logger, int motor_num, double alpha = 1.0, double beta = 0.0);
-    ~Motor();
+  Motor(rclcpp::Logger logger, int motor_num, double alpha = 1.0, double beta = 0.0);
+  ~Motor();
 
-    void setValue(double value);
-    void stop();
+  // Owns an I2C file descriptor; copying would double-close it. Held via
+  // std::unique_ptr in RobotController, so it is never copied — make that explicit.
+  Motor(const Motor &) = delete;
+  Motor & operator=(const Motor &) = delete;
+
+  void setValue(double value);
+  void stop();
 
 private:
-    rclcpp::Logger logger_;
-    int motor_num_, pwm_pin, fwd_pin, rev_pin, fwd_ch, rev_ch;
-    double alpha_, beta_, value_;
-    int i2c_fd_;
+  rclcpp::Logger logger_;
+  int motor_num_, pwm_pin, fwd_pin, rev_pin, fwd_ch, rev_ch;
+  double alpha_, beta_;
+  int i2c_fd_;
 
-    bool openI2C();
-    bool writeRegister(uint8_t reg, uint8_t value);
-    bool readRegister(uint8_t reg, uint8_t& value);
+  bool openI2C();
+  bool writeRegister(uint8_t reg, uint8_t value);
+  bool readRegister(uint8_t reg, uint8_t & value);
 
-    void resetPCA9685();
-    void setPWMFreq(int freq);
-    void setPWMValue(int channel, double value);
-    void setPWM(int channel, int on, int off);
-    void setPin(int pin, int value);
-    void setState(int value, int speed);
+  void resetPCA9685();
+  void setPWMFreq(int freq);
+  void setPWM(int channel, int on, int off);
+  void setPin(int pin, int value);
+  void setState(int value, int speed);
 };
 
 #endif

--- a/launch/gazebo_sim.launch.py
+++ b/launch/gazebo_sim.launch.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""DEPRECATED — Gazebo Classic launch for JeTank.
+"""
+DEPRECATED — Gazebo Classic launch for JeTank.
 
 This workspace standardised on Gazebo Fortress (Ignition) via ros_gz and
 ign_ros2_control. The RoboStack pixi environment does not ship Gazebo Classic

--- a/launch/test_urdf.launch.py
+++ b/launch/test_urdf.launch.py
@@ -5,7 +5,6 @@ Simple test launch file for JeTank URDF visualization.
 Tests URDF loading with robot_state_publisher and visualizes in RViz.
 """
 
-import os
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
@@ -72,7 +71,8 @@ def generate_launch_description():
         executable="rviz2",
         name="rviz2",
         output="screen",
-        arguments=["-d", PathJoinSubstitution([FindPackageShare("jetank_description"), "rviz", "urdf.rviz"])],
+        arguments=["-d", PathJoinSubstitution(
+            [FindPackageShare("jetank_description"), "rviz", "urdf.rviz"])],
     )
 
     return LaunchDescription(

--- a/package.xml
+++ b/package.xml
@@ -45,6 +45,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/motor/motor.cpp
+++ b/src/motor/motor.cpp
@@ -10,229 +10,221 @@
 #define PCA9685_ADDRESS 0x60
 #define MODE1 0x00
 #define MODE2  0x01
-#define SUBADR1 0x02
-#define SUBADR2 0x03
-#define SUBADR3 0x04
 #define PRESCALE 0xFE
 #define LED0_ON_L 0x06
-#define LED0_ON_H 0x07
-#define LED0_OFF_L 0x08
-#define LED0_OFF_H 0x09
-#define ALL_LED_ON_L 0xFA
-#define ALL_LED_ON_H 0xFB
-#define ALL_LED_OFF_L 0xFC
-#define ALL_LED_OFF_H  0xFD
 
 // Bits
-#define RESTART 0x80
 #define SLEEP 0x10
 #define ALLCALL 0x01
-#define INVRT 0x10
 #define OUTDRV 0x04
 
-
-
 Motor::Motor(rclcpp::Logger logger, int motor_num, double alpha, double beta)
-    : logger_(logger), motor_num_(motor_num), alpha_(alpha), beta_(beta), value_(0.0), i2c_fd_(-1) {
-    RCLCPP_INFO(logger_, "Initializing motor %d with alpha=%.3f, beta=%.3f", 
-                motor_num_, alpha_, beta_);
+: logger_(logger), motor_num_(motor_num), alpha_(alpha), beta_(beta), i2c_fd_(-1)
+{
+  RCLCPP_INFO(
+    logger_, "Initializing motor %d with alpha=%.3f, beta=%.3f",
+    motor_num_, alpha_, beta_);
 
-    if (motor_num_ == 0) {
-        pwm_pin = 8;
-        fwd_pin = 9;
-        rev_pin = 10;
-        fwd_ch = 0;
-        rev_ch = 1;
-    } else {
-        pwm_pin = 13;
-        fwd_pin = 12;
-        rev_pin = 11;
-        fwd_ch = 3;
-        rev_ch = 2;
-    }
-    
+  if (motor_num_ == 0) {
+    pwm_pin = 8;
+    fwd_pin = 9;
+    rev_pin = 10;
+    fwd_ch = 0;
+    rev_ch = 1;
+  } else {
+    pwm_pin = 13;
+    fwd_pin = 12;
+    rev_pin = 11;
+    fwd_ch = 3;
+    rev_ch = 2;
+  }
 
-    try {
-        if (!openI2C()) {
-            throw std::runtime_error("Failed to open I2C connection");
-        }
-        resetPCA9685();
-        setPWMFreq(1600); 
-    } catch (const std::runtime_error &e) {
-        RCLCPP_ERROR(logger_, "Motor %d initializing error: %s", motor_num_, e.what());
+
+  try {
+    if (!openI2C()) {
+      throw std::runtime_error("Failed to open I2C connection");
     }
-    RCLCPP_INFO(logger_, "Motor %d initialized succesfully", motor_num_);
+    resetPCA9685();
+    setPWMFreq(1600);
+  } catch (const std::runtime_error & e) {
+    RCLCPP_ERROR(logger_, "Motor %d initializing error: %s", motor_num_, e.what());
+  }
+  RCLCPP_INFO(logger_, "Motor %d initialized succesfully", motor_num_);
 
 }
 
-Motor::~Motor() {
-    if (i2c_fd_ >= 0) {
-        close(i2c_fd_);
-    }
+Motor::~Motor()
+{
+  if (i2c_fd_ >= 0) {
+    close(i2c_fd_);
+  }
 }
 
-void Motor::setValue(double value) {
-    try {
-        int mapped_value = static_cast<int>(255.0 * (alpha_ * value + beta_));
-        int speed = std::min(std::max(std::abs(mapped_value), 0), 255);
+void Motor::setValue(double value)
+{
+  try {
+    int mapped_value = static_cast<int>(255.0 * (alpha_ * value + beta_));
+    int speed = std::min(std::max(std::abs(mapped_value), 0), 255);
 
-        if (speed < 0) {
-            speed = 0;
-        } else if (speed > 255) {
-            speed = 255;
-        }
-
-        setState(mapped_value, speed);
-        RCLCPP_INFO(logger_, "Motor %d value setting, value = %f", motor_num_, value);
-    }
-    catch (...) {
-        RCLCPP_INFO(logger_, "Motor %d value setting failed", motor_num_);
-    }
+    setState(mapped_value, speed);
+    RCLCPP_INFO(logger_, "Motor %d value setting, value = %f", motor_num_, value);
+  } catch (...) {
+    RCLCPP_INFO(logger_, "Motor %d value setting failed", motor_num_);
+  }
 
 }
-void Motor::setState(int value, int speed) {
+void Motor::setState(int value, int speed)
+{
 
-    setPWM(pwm_pin, 0, speed*16);
-    if (value > 0) {
-        setPin(fwd_pin, 1);
-        setPin(rev_pin, 0);
-        setPWM(fwd_ch, 0, speed*16);
-        setPWM(rev_ch, 0, 0);
-    } else if (value < 0) {
-        setPin(fwd_pin, 0);
-        setPin(rev_pin, 1);
-        setPWM(rev_ch, 0, speed*16);
-        setPWM(fwd_ch, 0, 0);
-    } else {
-        setPin(fwd_pin, 0);
-        setPin(rev_pin, 0);
-    }
-    
-}
-
-void Motor::stop() {
+  setPWM(pwm_pin, 0, speed * 16);
+  if (value > 0) {
+    setPin(fwd_pin, 1);
+    setPin(rev_pin, 0);
+    setPWM(fwd_ch, 0, speed * 16);
+    setPWM(rev_ch, 0, 0);
+  } else if (value < 0) {
+    setPin(fwd_pin, 0);
+    setPin(rev_pin, 1);
+    setPWM(rev_ch, 0, speed * 16);
+    setPWM(fwd_ch, 0, 0);
+  } else {
     setPin(fwd_pin, 0);
     setPin(rev_pin, 0);
+  }
+
 }
 
-bool Motor::openI2C() {
-    const char* device = "/dev/i2c-7";
-    i2c_fd_ = open(device, O_RDWR);
-    if (i2c_fd_ < 0) {
-        std::cerr << "Failed to open I2C device" << std::endl;
-        RCLCPP_INFO(logger_, "Failed to open I2C device, while running motor %d", motor_num_);
-        return false;
-    }
-
-    if (ioctl(i2c_fd_, I2C_SLAVE, PCA9685_ADDRESS) < 0) {
-        std::cerr << "Failed to set I2C address" << std::endl;
-        RCLCPP_INFO(logger_, "Failed to set I2C address, while running motor %d", motor_num_);
-        close(i2c_fd_);
-        i2c_fd_ = -1;
-        return false;
-    }
-
-    RCLCPP_INFO(logger_, "I2C successfull, while running motor %d", motor_num_);
-    return true;
+void Motor::stop()
+{
+  setPin(fwd_pin, 0);
+  setPin(rev_pin, 0);
 }
 
-bool Motor::writeRegister(uint8_t reg, uint8_t value) {
-    if (i2c_fd_ < 0) {
-        RCLCPP_ERROR(logger_, "I2C not initialized");
-        return false;
-    }
-    
-    uint8_t buffer[2] = {reg, value};
-    int result = write(i2c_fd_, buffer, 2);
-    if (result != 2) {
-        RCLCPP_ERROR(logger_, "I2C write failed: reg=0x%02X, value=0x%02X", reg, value);
-        return false;
-    }
-    return true;
+bool Motor::openI2C()
+{
+  const char * device = "/dev/i2c-7";
+  i2c_fd_ = open(device, O_RDWR);
+  if (i2c_fd_ < 0) {
+    std::cerr << "Failed to open I2C device" << std::endl;
+    RCLCPP_INFO(logger_, "Failed to open I2C device, while running motor %d", motor_num_);
+    return false;
+  }
+
+  if (ioctl(i2c_fd_, I2C_SLAVE, PCA9685_ADDRESS) < 0) {
+    std::cerr << "Failed to set I2C address" << std::endl;
+    RCLCPP_INFO(logger_, "Failed to set I2C address, while running motor %d", motor_num_);
+    close(i2c_fd_);
+    i2c_fd_ = -1;
+    return false;
+  }
+
+  RCLCPP_INFO(logger_, "I2C successfull, while running motor %d", motor_num_);
+  return true;
 }
 
-bool Motor::readRegister(uint8_t reg, uint8_t& value) {
-    if (write(i2c_fd_, &reg, 1) != 1) {
-        return false;
-    }
+bool Motor::writeRegister(uint8_t reg, uint8_t value)
+{
+  if (i2c_fd_ < 0) {
+    RCLCPP_ERROR(logger_, "I2C not initialized");
+    return false;
+  }
 
-    if (read(i2c_fd_, &value, 1) != 1) {
-        return false;
-    }
-
-    return true;
+  uint8_t buffer[2] = {reg, value};
+  int result = write(i2c_fd_, buffer, 2);
+  if (result != 2) {
+    RCLCPP_ERROR(logger_, "I2C write failed: reg=0x%02X, value=0x%02X", reg, value);
+    return false;
+  }
+  return true;
 }
 
-void Motor::resetPCA9685() {
-    // Reset sequence
-    writeRegister(MODE1, 0x00);  // Clear all bits first
-    usleep(1000);
-    
-    // Wake up (clear sleep bit) and enable auto-increment
-    writeRegister(MODE1, ALLCALL);
-    usleep(1000);
-    
-    // Read current mode
-    uint8_t mode1;
-    readRegister(MODE1, mode1);
-    
-    // Clear sleep bit (wake up)
-    mode1 = mode1 & ~SLEEP;  // Clear sleep bit
-    writeRegister(MODE1, mode1);
-    usleep(1000);
-    
-    // Set output driver to totem pole
-    writeRegister(MODE2, OUTDRV);
-    usleep(1000);
-    
-    RCLCPP_INFO(logger_, "PCA9685 reset completed");
+bool Motor::readRegister(uint8_t reg, uint8_t & value)
+{
+  if (write(i2c_fd_, &reg, 1) != 1) {
+    return false;
+  }
+
+  if (read(i2c_fd_, &value, 1) != 1) {
+    return false;
+  }
+
+  return true;
 }
 
-void Motor::setPWMFreq(int freq) {
-    double prescaleval = 25000000.0 / (4096.0 * freq) - 1.0;
-    uint8_t prescale = static_cast<uint8_t>(std::floor(prescaleval + 0.5));
+void Motor::resetPCA9685()
+{
+  // Reset sequence
+  writeRegister(MODE1, 0x00);    // Clear all bits first
+  usleep(1000);
 
-    uint8_t oldmode;
-    readRegister(MODE1, oldmode);
-    uint8_t newmode = (oldmode & 0x7F) | 0x10;
+  // Wake up (clear sleep bit) and enable auto-increment
+  writeRegister(MODE1, ALLCALL);
+  usleep(1000);
 
-    writeRegister(MODE1, newmode);
-    writeRegister(PRESCALE, prescale);
-    writeRegister(MODE1, oldmode);
-    usleep(500);
-    writeRegister(MODE1, oldmode | 0x80);
+  // Read current mode
+  uint8_t mode1;
+  readRegister(MODE1, mode1);
+
+  // Clear sleep bit (wake up)
+  mode1 = mode1 & ~SLEEP;    // Clear sleep bit
+  writeRegister(MODE1, mode1);
+  usleep(1000);
+
+  // Set output driver to totem pole
+  writeRegister(MODE2, OUTDRV);
+  usleep(1000);
+
+  RCLCPP_INFO(logger_, "PCA9685 reset completed");
 }
 
-void Motor::setPWM(int channel, int on, int off) {
-    uint8_t reg = LED0_ON_L + 4 * channel;
-    writeRegister(reg, on & 0xFF);
-    writeRegister(reg + 1, on >> 8);
-    writeRegister(reg + 2, off & 0xFF);
-    writeRegister(reg + 3, off >> 8);
+void Motor::setPWMFreq(int freq)
+{
+  double prescaleval = 25000000.0 / (4096.0 * freq) - 1.0;
+  uint8_t prescale = static_cast<uint8_t>(std::floor(prescaleval + 0.5));
+
+  uint8_t oldmode;
+  readRegister(MODE1, oldmode);
+  uint8_t newmode = (oldmode & 0x7F) | 0x10;
+
+  writeRegister(MODE1, newmode);
+  writeRegister(PRESCALE, prescale);
+  writeRegister(MODE1, oldmode);
+  usleep(500);
+  writeRegister(MODE1, oldmode | 0x80);
 }
 
-void Motor::setPin(int pin, int value) {
-    // Validate pin number
-    if (pin < 0 || pin > 15) {
-        RCLCPP_ERROR(logger_, "Invalid pin number: %d. Pin must be between 0 and 15", pin);
-        return;
+void Motor::setPWM(int channel, int on, int off)
+{
+  uint8_t reg = LED0_ON_L + 4 * channel;
+  writeRegister(reg, on & 0xFF);
+  writeRegister(reg + 1, on >> 8);
+  writeRegister(reg + 2, off & 0xFF);
+  writeRegister(reg + 3, off >> 8);
+}
+
+void Motor::setPin(int pin, int value)
+{
+  // Validate pin number
+  if (pin < 0 || pin > 15) {
+    RCLCPP_ERROR(logger_, "Invalid pin number: %d. Pin must be between 0 and 15", pin);
+    return;
+  }
+
+  // Validate value parameter
+  if (value != 0 && value != 1) {
+    RCLCPP_ERROR(logger_, "Invalid value: %d. Value must be 0 or 1", value);
+    return;
+  }
+
+  try {
+    if (value == 0) {
+      setPWM(pin, 0, 4096);
+      RCLCPP_DEBUG(logger_, "Set pin %d to LOW (0)", pin);
+    } else if (value == 1) {
+      setPWM(pin, 4096, 0);
+      RCLCPP_DEBUG(logger_, "Set pin %d to HIGH (1)", pin);
     }
-    
-    // Validate value parameter
-    if (value != 0 && value != 1) {
-        RCLCPP_ERROR(logger_, "Invalid value: %d. Value must be 0 or 1", value);
-        return;
-    }
-    
-    try {
-        if (value == 0) {
-            setPWM(pin, 0, 4096);
-            RCLCPP_DEBUG(logger_, "Set pin %d to LOW (0)", pin);
-        } else if (value == 1) {
-            setPWM(pin, 4096, 0);
-            RCLCPP_DEBUG(logger_, "Set pin %d to HIGH (1)", pin);
-        }
-    } catch (const std::exception& e) {
-        RCLCPP_ERROR(logger_, "Failed to set PWM on pin %d: %s", pin, e.what());
-    }
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(logger_, "Failed to set PWM on pin %d: %s", pin, e.what());
+  }
 }

--- a/src/motor/robot_controller.cpp
+++ b/src/motor/robot_controller.cpp
@@ -6,156 +6,169 @@
 #include <sstream>
 #include "motor.hpp"
 
-class RobotController : public rclcpp::Node {
+class RobotController : public rclcpp::Node
+{
 public:
-    RobotController() : Node("robot_controller") {
-        // Declare parameters
-        this->declare_parameter<int>("left_motor", 0);
-        this->declare_parameter<int>("right_motor", 1);
-        this->declare_parameter<double>("left_motor_alpha", 1.0);
-        this->declare_parameter<double>("right_motor_alpha", 1.0);
-        this->declare_parameter<double>("left_motor_beta", 0.0);   // Add beta parameters
-        this->declare_parameter<double>("right_motor_beta", 0.0);
-        this->declare_parameter<double>("track_width", 0.11);
-        this->declare_parameter<double>("max_linear_velocity", 1.0);
-        this->declare_parameter<double>("max_angular_velocity", 2.0);
+  RobotController()
+  : Node("robot_controller")
+  {
+    // Declare parameters
+    this->declare_parameter<int>("left_motor", 0);
+    this->declare_parameter<int>("right_motor", 1);
+    this->declare_parameter<double>("left_motor_alpha", 1.0);
+    this->declare_parameter<double>("right_motor_alpha", 1.0);
+    this->declare_parameter<double>("left_motor_beta", 0.0);       // Add beta parameters
+    this->declare_parameter<double>("right_motor_beta", 0.0);
+    this->declare_parameter<double>("track_width", 0.11);
+    this->declare_parameter<double>("max_linear_velocity", 1.0);
+    this->declare_parameter<double>("max_angular_velocity", 2.0);
 
-        // Get parameters
-        int left_motor = this->get_parameter("left_motor").as_int();
-        int right_motor = this->get_parameter("right_motor").as_int();
-        double left_alpha = this->get_parameter("left_motor_alpha").as_double();
-        double right_alpha = this->get_parameter("right_motor_alpha").as_double();
-        double left_beta = this->get_parameter("left_motor_beta").as_double();
-        double right_beta = this->get_parameter("right_motor_beta").as_double();
-        track_width_ = this->get_parameter("track_width").as_double();
-        max_linear_velocity_ = this->get_parameter("max_linear_velocity").as_double();
-        max_angular_velocity_ = this->get_parameter("max_angular_velocity").as_double();
+    // Get parameters
+    int left_motor = this->get_parameter("left_motor").as_int();
+    int right_motor = this->get_parameter("right_motor").as_int();
+    double left_alpha = this->get_parameter("left_motor_alpha").as_double();
+    double right_alpha = this->get_parameter("right_motor_alpha").as_double();
+    double left_beta = this->get_parameter("left_motor_beta").as_double();
+    double right_beta = this->get_parameter("right_motor_beta").as_double();
+    track_width_ = this->get_parameter("track_width").as_double();
+    max_linear_velocity_ = this->get_parameter("max_linear_velocity").as_double();
+    max_angular_velocity_ = this->get_parameter("max_angular_velocity").as_double();
 
-        left_motor_ = std::make_unique<Motor>(this->get_logger(), left_motor, left_alpha, left_beta);
-        right_motor_ = std::make_unique<Motor>(this->get_logger(), right_motor, right_alpha, right_beta);
+    left_motor_ = std::make_unique<Motor>(this->get_logger(), left_motor, left_alpha, left_beta);
+    right_motor_ = std::make_unique<Motor>(
+      this->get_logger(), right_motor, right_alpha,
+      right_beta);
 
-        stop();
+    stop();
 
-        cmd_vel_subscription_ = this->create_subscription<geometry_msgs::msg::Twist>(
-            "/cmd_vel", 
-            10, 
-            std::bind(&RobotController::cmdVelCallback, this, std::placeholders::_1)
-        );
+    cmd_vel_subscription_ = this->create_subscription<geometry_msgs::msg::Twist>(
+      "/cmd_vel",
+      10,
+      std::bind(&RobotController::cmdVelCallback, this, std::placeholders::_1)
+    );
 
-        status_publisher_ = this->create_publisher<std_msgs::msg::String>("robot_status", 10);
+    status_publisher_ = this->create_publisher<std_msgs::msg::String>("robot_status", 10);
 
-        timer_ = this->create_wall_timer(
-            std::chrono::milliseconds(1000),
-            std::bind(&RobotController::publishStatus, this)
-        );
+    timer_ = this->create_wall_timer(
+      std::chrono::milliseconds(1000),
+      std::bind(&RobotController::publishStatus, this)
+    );
 
-        safety_timer_ = this->create_wall_timer(
-            std::chrono::milliseconds(500),
-            std::bind(&RobotController::safetyCheck, this)
-        );
+    safety_timer_ = this->create_wall_timer(
+      std::chrono::milliseconds(500),
+      std::bind(&RobotController::safetyCheck, this)
+    );
 
-        last_cmd_time_ = this->get_clock()->now();
+    last_cmd_time_ = this->get_clock()->now();
 
-        RCLCPP_INFO(this->get_logger(), "Robot controller initialized");
-    }
+    RCLCPP_INFO(this->get_logger(), "Robot controller initialized");
+  }
 
-    ~RobotController() {
-        stop();
-        RCLCPP_INFO(this->get_logger(), "Robot controller shutting down");
-    }
+  ~RobotController()
+  {
+    stop();
+    RCLCPP_INFO(this->get_logger(), "Robot controller shutting down");
+  }
 
 private:
-    void cmdVelCallback(const geometry_msgs::msg::Twist::SharedPtr msg) {
-        last_cmd_time_ = this->get_clock()->now();
+  void cmdVelCallback(const geometry_msgs::msg::Twist::SharedPtr msg)
+  {
+    last_cmd_time_ = this->get_clock()->now();
 
-        double lin_vel = msg->linear.x;
-        double ang_vel = msg->angular.z;
+    double lin_vel = msg->linear.x;
+    double ang_vel = msg->angular.z;
 
-        lin_vel = std::max(-max_linear_velocity_, std::min(max_linear_velocity_, lin_vel));
-        ang_vel = std::max(-max_angular_velocity_, std::min(max_angular_velocity_, ang_vel));
+    lin_vel = std::max(-max_linear_velocity_, std::min(max_linear_velocity_, lin_vel));
+    ang_vel = std::max(-max_angular_velocity_, std::min(max_angular_velocity_, ang_vel));
 
-        double left_vel = lin_vel - (ang_vel * track_width_ / 2.0);
-        double right_vel = lin_vel + (ang_vel * track_width_ / 2.0);
+    double left_vel = lin_vel - (ang_vel * track_width_ / 2.0);
+    double right_vel = lin_vel + (ang_vel * track_width_ / 2.0);
 
-        double max_wheel_vel = std::max(std::abs(left_vel), std::abs(right_vel));
-        if (max_wheel_vel > max_linear_velocity_) {
-            left_vel = left_vel / max_wheel_vel * max_linear_velocity_;
-            right_vel = right_vel / max_wheel_vel * max_linear_velocity_;
-        }
-
-        left_vel = std::clamp(left_vel / max_linear_velocity_, -1.0, 1.0);
-        right_vel = std::clamp(right_vel / max_linear_velocity_, -1.0, 1.0);
-
-        left_motor_->setValue(left_vel);
-        right_motor_->setValue(right_vel);
-
-        last_left_value_ = left_vel;
-        last_right_value_ = right_vel;
+    double max_wheel_vel = std::max(std::abs(left_vel), std::abs(right_vel));
+    if (max_wheel_vel > max_linear_velocity_) {
+      left_vel = left_vel / max_wheel_vel * max_linear_velocity_;
+      right_vel = right_vel / max_wheel_vel * max_linear_velocity_;
     }
 
-    void publishStatus() {
-        auto message = std_msgs::msg::String();
-        std::ostringstream ss;
-        ss << "Robot Status. Left=" << last_left_value_
-           << " Right=" << last_right_value_
-           << " Standby: Active";
-        message.data = ss.str();
-        status_publisher_->publish(message);
+    left_vel = std::clamp(left_vel / max_linear_velocity_, -1.0, 1.0);
+    right_vel = std::clamp(right_vel / max_linear_velocity_, -1.0, 1.0);
+
+    left_motor_->setValue(left_vel);
+    right_motor_->setValue(right_vel);
+
+    last_left_value_ = left_vel;
+    last_right_value_ = right_vel;
+  }
+
+  void publishStatus()
+  {
+    auto message = std_msgs::msg::String();
+    std::ostringstream ss;
+    ss << "Robot Status. Left=" << last_left_value_
+       << " Right=" << last_right_value_
+       << " Standby: Active";
+    message.data = ss.str();
+    status_publisher_->publish(message);
+  }
+
+  void safetyCheck()
+  {
+    auto now = this->get_clock()->now();
+    auto time_since_last_cmd = now - last_cmd_time_;
+
+    if (time_since_last_cmd.seconds() > 1.0) {
+      stop();
+      RCLCPP_WARN_THROTTLE(
+        this->get_logger(), *this->get_clock(), 5000,
+        "No cmd_vel received for %.1f seconds, motors stopped",
+        time_since_last_cmd.seconds());
     }
+  }
 
-    void safetyCheck() {
-        auto now = this->get_clock()->now();
-        auto time_since_last_cmd = now - last_cmd_time_;
+  void stop()
+  {
+    left_motor_->stop();
+    right_motor_->stop();
+    last_left_value_ = 0.0;
+    last_right_value_ = 0.0;
+  }
 
-        if (time_since_last_cmd.seconds() > 1.0) {
-            stop();
-            RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
-                                "No cmd_vel received for %.1f seconds, motors stopped", 
-                                time_since_last_cmd.seconds());
-        }
-    }
+  std::unique_ptr<Motor> left_motor_;
+  std::unique_ptr<Motor> right_motor_;
 
-    void stop() {
-        left_motor_->stop();
-        right_motor_->stop();
-        last_left_value_ = 0.0;
-        last_right_value_ = 0.0;
-    }
+  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_subscription_;
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr status_publisher_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::TimerBase::SharedPtr safety_timer_;
 
-    std::unique_ptr<Motor> left_motor_;
-    std::unique_ptr<Motor> right_motor_;
+  double track_width_;
+  double max_linear_velocity_;
+  double max_angular_velocity_;
 
-    rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_subscription_;
-    rclcpp::Publisher<std_msgs::msg::String>::SharedPtr status_publisher_;
-    rclcpp::TimerBase::SharedPtr timer_;
-    rclcpp::TimerBase::SharedPtr safety_timer_;
+  double last_left_value_ = 0.0;
+  double last_right_value_ = 0.0;
 
-    double track_width_;
-    double max_linear_velocity_;
-    double max_angular_velocity_;
-
-    double last_left_value_ = 0.0;
-    double last_right_value_ = 0.0;
-
-    rclcpp::Time last_cmd_time_;
+  rclcpp::Time last_cmd_time_;
 };
 
-int main(int argc, char * argv[]) {
-    rclcpp::init(argc, argv);
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
 
-    try {
-        auto node = std::make_shared<RobotController>();
+  try {
+    auto node = std::make_shared<RobotController>();
 
-        rclcpp::on_shutdown([node]() {
-            RCLCPP_INFO(node->get_logger(), "Shutting down JetTank robot controller...");
-        });
+    rclcpp::on_shutdown(
+      [node]() {
+        RCLCPP_INFO(node->get_logger(), "Shutting down JetTank robot controller...");
+      });
 
-        rclcpp::spin(node);
-    } catch (const std::exception& e) {
-        RCLCPP_ERROR(rclcpp::get_logger("robot_controller"), "Exception: %s", e.what());
-        return 1;
-    }
+    rclcpp::spin(node);
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(rclcpp::get_logger("robot_controller"), "Exception: %s", e.what());
+    return 1;
+  }
 
-    rclcpp::shutdown();
-    return 0;
+  rclcpp::shutdown();
+  return 0;
 }

--- a/test/test_motor_header.cpp
+++ b/test/test_motor_header.cpp
@@ -1,0 +1,57 @@
+// Compile/contract tests for the Motor hardware-driver header.
+//
+// The Motor constructor opens an I2C device, so a Motor instance cannot be
+// created in a unit-test environment without hardware. These tests therefore
+// exercise the header's public contract at compile time via type traits,
+// proving that motor.hpp parses, that Motor's declared interface is stable,
+// and that it cannot be misused (no default / copy construction). They link
+// against the real motor.cpp translation unit through jetank_motor_lib.
+
+#include <type_traits>
+
+#include "gtest/gtest.h"
+#include "rclcpp/rclcpp.hpp"
+
+#include "motor.hpp"
+
+// Motor owns an I2C file descriptor; it must not be default-constructible
+// (the only constructor requires a logger and motor number).
+TEST(MotorHeader, NotDefaultConstructible)
+{
+  EXPECT_FALSE(std::is_default_constructible<Motor>::value);
+}
+
+// Motor manages a raw resource (i2c_fd_) and is held via std::unique_ptr in
+// RobotController, so accidental copying must be impossible.
+TEST(MotorHeader, NotCopyConstructible)
+{
+  EXPECT_FALSE(std::is_copy_constructible<Motor>::value);
+  EXPECT_FALSE(std::is_copy_assignable<Motor>::value);
+}
+
+// The documented constructor signature
+//   Motor(rclcpp::Logger, int, double = 1.0, double = 0.0)
+// must remain callable with both its required and its full argument list.
+TEST(MotorHeader, ConstructorSignatureStable)
+{
+  EXPECT_TRUE((std::is_constructible<Motor, rclcpp::Logger, int>::value));
+  EXPECT_TRUE((std::is_constructible<Motor, rclcpp::Logger, int, double>::value));
+  EXPECT_TRUE(
+    (std::is_constructible<Motor, rclcpp::Logger, int, double, double>::value));
+}
+
+// setValue / stop are the public control surface; their member-pointer types
+// must keep their signatures (void(double) and void()).
+TEST(MotorHeader, PublicControlSurfaceStable)
+{
+  void (Motor::* set_value)(double) = &Motor::setValue;
+  void (Motor::* stop)() = &Motor::stop;
+  EXPECT_NE(set_value, nullptr);
+  EXPECT_NE(stop, nullptr);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
**Fix:** delete `Motor` copy ctor/assign — it owns an I2C fd and is held via `unique_ptr`; copying would double-close. No current caller copies it (behavior-preserving).
**Conciseness:** remove unused `value_` member, `setPWMValue`, a dead clamp branch in `setValue`, unused PCA9685 `#define`s; uncrustify reformat.
**Tests:** add `test/test_motor_header.cpp` (4 gtest contract checks; Motor can't be unit-instantiated — opens I2C).
**Docs:** README Tests section.

_Part of a workspace-wide behavior-preserving conciseness + real-tests pass. `colcon test` residuals are non-functional lint only (pep257 D213 vs repo D212; offline xmllint)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)